### PR TITLE
Allow unused_labels to avoid confusing CLion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ fn then(mut context: Context) -> Result<proc_macro2::TokenStream, Error> {
 
     Ok(quote! {
         #(#attributes)*
-        #[allow(unused_variables, unused_mut)]
+        #[allow(unused_variables, unused_mut, unused_labels)]
         #asyncness fn #ident() {
             println!("\n{}", #scenario_description);
             #(#test_body)*


### PR DESCRIPTION
The CLion Rust plugin complains about our beady labels being unused, even though they are completely stripped in the generated code. It doesn't seem to see through all the macro expansions recursively, only a single level, so lets give it a hint.